### PR TITLE
Decrypt messages

### DIFF
--- a/Sources/BitcloutIdentity/BitcloutIdentity.swift
+++ b/Sources/BitcloutIdentity/BitcloutIdentity.swift
@@ -101,9 +101,9 @@ public class Identity {
      - Parameter threads: An array of `EncryptedMessagesThread` objects to be decrypted
      - Returns: A dictionary with keys of the publicKeys of the threads and values of the messages contained in the thread, in the order they were sent
      */
-    public func decrypt(_ threads: [EncryptedMessagesThread]) throws -> [String: [String]] {
+    public func decrypt(_ threads: [EncryptedMessagesThread], for myPublicKey: String) throws -> [String: [String]] {
         // TODO: Check if logged in and throw error if not
-        return try messageDecrypter.decryptMessages(threads)
+        return try messageDecrypter.decryptMessages(threads, for: myPublicKey)
     }
 
     /**

--- a/Sources/BitcloutIdentity/BitcloutIdentity.swift
+++ b/Sources/BitcloutIdentity/BitcloutIdentity.swift
@@ -97,13 +97,27 @@ public class Identity {
     }
 
     /**
-     Decrypt private messages
-     - Parameter threads: An array of `EncryptedMessagesThread` objects to be decrypted
+     Decrypt private messages from a collection of threads
+     - Parameters:
+        - threads: An array of `EncryptedMessagesThread` objects to be decrypted
+        - myPublicKey: The public key of the calling user's account
+        - errorOnFailure: true if failure to decrypt messages should return an error, false if messages which cannot be decrypted should just be ommitted from the results
      - Returns: A dictionary with keys of the publicKeys of the threads and values of the messages contained in the thread, in the order they were sent
      */
-    public func decrypt(_ threads: [EncryptedMessagesThread], for myPublicKey: String) throws -> [String: [String]] {
-        // TODO: Check if logged in and throw error if not
-        return try messageDecrypter.decryptMessages(threads, for: myPublicKey)
+    public func decrypt(_ threads: [EncryptedMessagesThread], for myPublicKey: String, errorOnFailure: Bool = false) throws -> [String: [String]] {
+        return try messageDecrypter.decryptThreads(threads, for: myPublicKey, errorOnFailure: errorOnFailure)
+    }
+    
+    /**
+     Decrypt private messages from a single thread
+     - Parameters:
+        - thread: An `EncryptedMessagesThread` object to be decrypted
+        - myPublicKey: The public key of the calling user's account
+        - errorOnFailure: true if failure to decrypt messages should return an error, false if messages which cannot be decrypted should just be ommitted from the results
+     - Returns: An array of decrypted message strings in the order they were sent
+     */
+    public func decrypt(_ thread: EncryptedMessagesThread, for myPublicKey: String, errorOnFailure: Bool = false) throws -> [String] {
+        return try messageDecrypter.decryptThread(thread, for: myPublicKey, errorOnFailure: errorOnFailure)
     }
 
     /**

--- a/Sources/BitcloutIdentity/Models/Errors.swift
+++ b/Sources/BitcloutIdentity/Models/Errors.swift
@@ -12,6 +12,7 @@ public enum IdentityError: Swift.Error {
     case notLoggedIn
     case missingInfoForPublicKey
     case keyInfoExpired
+    case missingSharedSecret
 }
 
 enum CryptoError: Swift.Error {

--- a/Sources/BitcloutIdentity/Models/SharedSecret.swift
+++ b/Sources/BitcloutIdentity/Models/SharedSecret.swift
@@ -11,4 +11,5 @@ struct SharedSecret: Codable {
     let secret: String
     let privateKey: String
     let publicKey: String
+    let myTruePublicKey: String
 }

--- a/Sources/BitcloutIdentity/Workers/Crypto/ECIES.swift
+++ b/Sources/BitcloutIdentity/Workers/Crypto/ECIES.swift
@@ -181,6 +181,13 @@ func encryptShared(privateKeySender: [UInt8],
                    ephemPrivateKey: [UInt8]? = nil,
                    iv: [UInt8]? = nil) throws -> [UInt8] {
     let sharedPx = try derive(privateKeyA: privateKeySender, publicKeyB: publicKeyRecipient)
+    return try encryptShared(sharedPx: sharedPx, msg: msg, ephemPrivateKey: ephemPrivateKey, iv: iv)
+}
+
+func encryptShared(sharedPx: [UInt8],
+                   msg: [UInt8],
+                   ephemPrivateKey: [UInt8]? = nil,
+                   iv: [UInt8]? = nil) throws -> [UInt8] {
     let sharedPrivateKey = kdf(secret: sharedPx, outputLength: 32)
     let sharedPublicKey = try getPublicKey(from: sharedPrivateKey)
     
@@ -196,6 +203,10 @@ func encryptShared(privateKeySender: [UInt8],
  */
 func decryptShared(privateKeyRecipient: [UInt8], publicKeySender: [UInt8], encrypted: [UInt8]) throws -> [UInt8] {
     let sharedPx = try derive(privateKeyA: privateKeyRecipient, publicKeyB: publicKeySender)
+    return try decryptShared(sharedPx: sharedPx, encrypted: encrypted)
+}
+
+func decryptShared(sharedPx: [UInt8], encrypted: [UInt8]) throws -> [UInt8] {
     let sharedPrivateKey = kdf(secret: sharedPx, outputLength: 32)
     return try decrypt(privateKey: sharedPrivateKey, encrypted: encrypted)
 }

--- a/Sources/BitcloutIdentity/Workers/KeyInfoStorageWorker.swift
+++ b/Sources/BitcloutIdentity/Workers/KeyInfoStorageWorker.swift
@@ -17,6 +17,8 @@ protocol KeyInfoStorable {
     func clearSharedSecret(for privateKey: String, and publicKey: String) throws
     func getDerivedKeyInfo(for publicKey: String) throws -> DerivedKeyInfo?
     func getAllStoredKeys() throws -> [String]
+    func getSharedSecret(for myPrivateKey: String, and otherPublicKey: String) throws -> SharedSecret
+    func getAllSharedSecrets() throws -> [SharedSecret]
 }
 
 class KeyInfoStorageWorker: KeyInfoStorable {
@@ -94,6 +96,14 @@ class KeyInfoStorageWorker: KeyInfoStorable {
         guard let data = try keychain.getData(Keys.derivedKeyInfo.rawValue) else { return [] }
         let storedData = try JSONDecoder().decode([String: DerivedKeyInfo].self, from: data)
         return storedData.keys.map { $0 }
+    }
+    
+    func getSharedSecret(for myPrivateKey: String, and otherPublicKey: String) throws -> SharedSecret? {
+        let sharedSecrets = try getAllSharedSecrets()
+        return sharedSecrets
+            .first {
+                $0.privateKey == myPrivateKey && $0.publicKey == otherPublicKey
+            }
     }
     
     func getAllSharedSecrets() throws -> [SharedSecret] {

--- a/Sources/BitcloutIdentity/Workers/KeyInfoStorageWorker.swift
+++ b/Sources/BitcloutIdentity/Workers/KeyInfoStorageWorker.swift
@@ -17,7 +17,7 @@ protocol KeyInfoStorable {
     func clearSharedSecret(for privateKey: String, and publicKey: String) throws
     func getDerivedKeyInfo(for publicKey: String) throws -> DerivedKeyInfo?
     func getAllStoredKeys() throws -> [String]
-    func getSharedSecret(for myPrivateKey: String, and otherPublicKey: String) throws -> SharedSecret
+    func getSharedSecret(for myPublicKey: String, and otherPublicKey: String) throws -> SharedSecret?
     func getAllSharedSecrets() throws -> [SharedSecret]
 }
 
@@ -98,11 +98,11 @@ class KeyInfoStorageWorker: KeyInfoStorable {
         return storedData.keys.map { $0 }
     }
     
-    func getSharedSecret(for myPrivateKey: String, and otherPublicKey: String) throws -> SharedSecret? {
+    func getSharedSecret(for myPublicKey: String, and otherPublicKey: String) throws -> SharedSecret? {
         let sharedSecrets = try getAllSharedSecrets()
         return sharedSecrets
             .first {
-                $0.privateKey == myPrivateKey && $0.publicKey == otherPublicKey
+                $0.myTruePublicKey == myPublicKey && $0.publicKey == otherPublicKey
             }
     }
     

--- a/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
+++ b/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
@@ -36,8 +36,14 @@ class MessageDecryptionWorker: MessageDecryptable {
         guard let sharedSecret = try? keyStore.getSharedSecret(for: publicKey, and: thread.publicKey) else {
             throw IdentityError.missingSharedSecret
         }
+        var decrypted: [String] = []
         do {
-        let decrypted = try decrypt(messages: thread.encryptedMessages, with: sharedSecret)
+            decrypted = try decrypt(messages: thread.encryptedMessages, with: sharedSecret)
+        } catch {
+            if errorOnFailure {
+                throw error
+            }
+        }
         return decrypted
     }
     

--- a/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
+++ b/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 protocol MessageDecryptable {
-    // TODO: confirm interface. May need a public key/other crypto info passed as well
-    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread], for privateKey: String) throws -> [String: [String]]
+    func decryptThreads(_ encryptedMessageThreads: [EncryptedMessagesThread], for publicKey: String, errorOnFailure: Bool) throws -> [String: [String]]
+    func decryptThread(_ thread: EncryptedMessagesThread, for publicKey: String, errorOnFailure: Bool) throws -> [String]
 }
 
 class MessageDecryptionWorker: MessageDecryptable {
@@ -20,22 +20,32 @@ class MessageDecryptionWorker: MessageDecryptable {
         self.keyStore = keyStore
     }
     
-    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread], for privateKey: String) throws -> [String: [String]] {
-        // TODO: Actually decrypt the messages
-        return encryptedMessageThreads.reduce(into: [:], { res, this in
-            guard let sharedSecret = try? keyStore.getSharedSecret(for: privateKey, and: this.publicKey) else {
-                return
+    func decryptThreads(_ encryptedMessageThreads: [EncryptedMessagesThread], for publicKey: String, errorOnFailure: Bool) throws -> [String: [String]] {
+        return try encryptedMessageThreads.reduce(into: [:], { res, this in
+            do {
+                res[this.publicKey] = try decryptThread(this, for: publicKey, errorOnFailure: errorOnFailure)
+            } catch {
+                if errorOnFailure {
+                    throw error
+                }
             }
-            let decrypted = decrypt(messages: this.encryptedMessages, with: sharedSecret)
-            res[this.publicKey] = decrypted
         })
     }
     
-    private func decrypt(messages: [String], with secret: SharedSecret) -> [String] {
-        return messages.compactMap {
-            return try? decryptShared(privateKeyRecipient: secret.privateKey.uInt8Array,
-                                          publicKeySender: secret.publicKey.uInt8Array,
-                                          encrypted: $0.uInt8Array).stringValue
+    func decryptThread(_ thread: EncryptedMessagesThread, for publicKey: String, errorOnFailure: Bool) throws -> [String] {
+        guard let sharedSecret = try? keyStore.getSharedSecret(for: publicKey, and: thread.publicKey) else {
+            throw IdentityError.missingSharedSecret
+        }
+        do {
+        let decrypted = try decrypt(messages: thread.encryptedMessages, with: sharedSecret)
+        return decrypted
+    }
+    
+    private func decrypt(messages: [String], with secret: SharedSecret) throws -> [String] {
+        return try messages.compactMap {
+            return try decryptShared(privateKeyRecipient: secret.privateKey.uInt8Array,
+                                      publicKeySender: secret.publicKey.uInt8Array,
+                                      encrypted: $0.uInt8Array).stringValue
         }
     }
 }

--- a/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
+++ b/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
@@ -9,14 +9,33 @@ import Foundation
 
 protocol MessageDecryptable {
     // TODO: confirm interface. May need a public key/other crypto info passed as well
-    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread]) throws -> [String: [String]]
+    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread], for privateKey: String) throws -> [String: [String]]
 }
 
 class MessageDecryptionWorker: MessageDecryptable {
-    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread]) throws -> [String: [String]] {
+    
+    private let keyStore: KeyInfoStorable
+    
+    init(keyStore: KeyInfoStorable = KeyInfoStorageWorker()) {
+        self.keyStore = keyStore
+    }
+    
+    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread], for privateKey: String) throws -> [String: [String]] {
         // TODO: Actually decrypt the messages
         return encryptedMessageThreads.reduce(into: [:], { res, this in
-            res[this.publicKey] = this.encryptedMessages
+            guard let sharedSecret = try? keyStore.getSharedSecret(for: privateKey, and: this.publicKey) else {
+                return
+            }
+            let decrypted = decrypt(messages: this.encryptedMessages, with: sharedSecret)
+            res[this.publicKey] = decrypted
         })
+    }
+    
+    private func decrypt(messages: [String], with secret: SharedSecret) -> [String] {
+        return messages.compactMap {
+            return try? decryptShared(privateKeyRecipient: secret.privateKey.uInt8Array,
+                                          publicKeySender: secret.publicKey.uInt8Array,
+                                          encrypted: $0.uInt8Array).stringValue
+        }
     }
 }

--- a/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
+++ b/Sources/BitcloutIdentity/Workers/MessageDecryptionWorker.swift
@@ -49,9 +49,8 @@ class MessageDecryptionWorker: MessageDecryptable {
     
     private func decrypt(messages: [String], with secret: SharedSecret) throws -> [String] {
         return try messages.compactMap {
-            return try decryptShared(privateKeyRecipient: secret.privateKey.uInt8Array,
-                                      publicKeySender: secret.publicKey.uInt8Array,
-                                      encrypted: $0.uInt8Array).stringValue
+            return try decryptShared(sharedPx: secret.secret.uInt8Array,
+                                     encrypted: $0.uInt8Array).stringValue
         }
     }
 }

--- a/Tests/BitcloutIdentityTests/BitcloutIdentityTests.swift
+++ b/Tests/BitcloutIdentityTests/BitcloutIdentityTests.swift
@@ -61,14 +61,26 @@
             XCTAssertEqual(transactionSigner.transactionRequestedForSign, transaction)
         }
         
-        func testDecryptCallsMessageDecrypter() {
+        func testDecryptThreadsCallsMessageDecrypter() {
             let encrypted = [EncryptedMessagesThread(publicKey: "alalalala",
                                                      encryptedMessages: ["foo", "foobar", "batbla"])]
             let myPublicKey = "ghghghgh"
-            let _ = try! sut.decrypt(encrypted, for: myPublicKey)
-            XCTAssertTrue(messageDecrypter.calledDecryptMessages)
+            let _ = try! sut.decrypt(encrypted, for: myPublicKey, errorOnFailure: true)
+            XCTAssertTrue(messageDecrypter.calledDecryptThreads)
             XCTAssertEqual(messageDecrypter.messagesToDecrypt, encrypted)
             XCTAssertEqual(messageDecrypter.publicKeyToDecryptFor, myPublicKey)
+            XCTAssertEqual(messageDecrypter.errorOnFailure, true)
+        }
+        
+        func testDecryptSingleThreadCallsMessageDecrypter() {
+            let encrypted = EncryptedMessagesThread(publicKey: "alalalala",
+                                                     encryptedMessages: ["foo", "foobar", "batbla"])
+            let myPublicKey = "ghghghgh"
+            let _ = try! sut.decrypt(encrypted, for: myPublicKey, errorOnFailure: true)
+            XCTAssertTrue(messageDecrypter.calledDecryptThread)
+            XCTAssertEqual(messageDecrypter.threadToDecrypt, encrypted)
+            XCTAssertEqual(messageDecrypter.publicKeyToDecryptFor, myPublicKey)
+            XCTAssertEqual(messageDecrypter.errorOnFailure, true)
         }
         
         func testJWTCallsJWTWorker() {

--- a/Tests/BitcloutIdentityTests/BitcloutIdentityTests.swift
+++ b/Tests/BitcloutIdentityTests/BitcloutIdentityTests.swift
@@ -48,8 +48,6 @@
             XCTAssertTrue(keyStore.calledGetAllStoredKeys)
         }
         
-        
-        
         func testRemoveAllKeysCallsKeyStore() {
             try! sut.removeAllKeys()
             XCTAssertTrue(keyStore.calledClearAllStoredInfo)
@@ -66,9 +64,11 @@
         func testDecryptCallsMessageDecrypter() {
             let encrypted = [EncryptedMessagesThread(publicKey: "alalalala",
                                                      encryptedMessages: ["foo", "foobar", "batbla"])]
-            let _ = try! sut.decrypt(encrypted)
+            let myPublicKey = "ghghghgh"
+            let _ = try! sut.decrypt(encrypted, for: myPublicKey)
             XCTAssertTrue(messageDecrypter.calledDecryptMessages)
             XCTAssertEqual(messageDecrypter.messagesToDecrypt, encrypted)
+            XCTAssertEqual(messageDecrypter.publicKeyToDecryptFor, myPublicKey)
         }
         
         func testJWTCallsJWTWorker() {

--- a/Tests/BitcloutIdentityTests/ECIESTests.swift
+++ b/Tests/BitcloutIdentityTests/ECIESTests.swift
@@ -87,4 +87,22 @@ final class ECIESTests: XCTestCase {
         let decryptedText = decrypted.stringValue
         XCTAssertEqual(msgText, decryptedText)
     }
+    
+    func testEncryptDecryptWithSharedSecret() {
+        let keysA = getRandomKeypair()!
+        let keysB = getRandomKeypair()!
+        let msgText = "Hello, World!"
+        let msg = msgText.uInt8Array
+        XCTAssertNotEqual(msg.count, 0)
+        
+        let sharedPx = try! derive(privateKeyA: keysA.private, publicKeyB: keysB.public)
+        XCTAssertNotEqual(sharedPx.count, 0)
+        
+        let encrypted = try! encryptShared(sharedPx: sharedPx, msg: msg)
+        XCTAssertNotEqual(msg, encrypted)
+        
+        let decrypted = try! decryptShared(sharedPx: sharedPx, encrypted: encrypted)
+        let decryptedText = decrypted.stringValue
+        XCTAssertEqual(msgText, decryptedText)
+    }
 }

--- a/Tests/BitcloutIdentityTests/Mocks/MockKeyStore.swift
+++ b/Tests/BitcloutIdentityTests/Mocks/MockKeyStore.swift
@@ -15,6 +15,11 @@ class MockKeyStore: KeyInfoStorable {
                                                   signedHash: "bla",
                                                   jwt: "joooot")
     
+    var mockSharedSecret: SharedSecret? = SharedSecret(secret: "foo",
+                                                       privateKey: "bar",
+                                                       publicKey: "bat",
+                                                       myTruePublicKey: "foobarbat")
+    
     var calledStoreInfo: Bool = false
     var infoRequestedToStore: DerivedKeyInfo?
     func store(_ info: DerivedKeyInfo) throws {
@@ -41,6 +46,22 @@ class MockKeyStore: KeyInfoStorable {
     func getAllStoredKeys() throws -> [String] {
         calledGetAllStoredKeys = true
         return ["foo"]
+    }
+    
+    var calledGetSharedSecret: Bool = false
+    var myPublicKeyToGetSharedSecret: String?
+    var otherPublicKeyToGetSharedSecret: String?
+    func getSharedSecret(for myPublicKey: String, and otherPublicKey: String) throws -> SharedSecret? {
+        calledGetSharedSecret = true
+        myPublicKeyToGetSharedSecret = myPublicKey
+        otherPublicKeyToGetSharedSecret = otherPublicKey
+        return mockSharedSecret
+    }
+    
+    var calledGetAllSharedSecrets: Bool = false
+    func getAllSharedSecrets() throws -> [SharedSecret] {
+        calledGetAllSharedSecrets = true
+        return [mockSharedSecret!]
     }
     
     var calledStoreSharedSecret: Bool = false

--- a/Tests/BitcloutIdentityTests/Mocks/MockMessageDecrypter.swift
+++ b/Tests/BitcloutIdentityTests/Mocks/MockMessageDecrypter.swift
@@ -10,13 +10,25 @@ import Foundation
 
 class MockMessageDecrypter: MessageDecryptable {
     var mockDecryptedMessages = ["foo": ["bar"], "bar": ["bat"], "bat": ["foo"]]
-    var calledDecryptMessages: Bool = false
+    var calledDecryptThreads: Bool = false
     var messagesToDecrypt: [EncryptedMessagesThread]?
     var publicKeyToDecryptFor: String?
-    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread], for myPublicKey: String) throws -> [String: [String]] {
-        calledDecryptMessages = true
+    var errorOnFailure: Bool?
+    func decryptThreads(_ encryptedMessageThreads: [EncryptedMessagesThread], for myPublicKey: String, errorOnFailure: Bool) throws -> [String: [String]] {
+        calledDecryptThreads = true
         messagesToDecrypt = encryptedMessageThreads
         publicKeyToDecryptFor = myPublicKey
+        self.errorOnFailure = errorOnFailure
         return mockDecryptedMessages
+    }
+    
+    var calledDecryptThread: Bool = false
+    var threadToDecrypt: EncryptedMessagesThread?
+    func decryptThread(_ thread: EncryptedMessagesThread, for publicKey: String, errorOnFailure: Bool) throws -> [String] {
+        calledDecryptThread = true
+        threadToDecrypt = thread
+        publicKeyToDecryptFor = publicKey
+        self.errorOnFailure = errorOnFailure
+        return mockDecryptedMessages[thread.publicKey] ?? []
     }
 }

--- a/Tests/BitcloutIdentityTests/Mocks/MockMessageDecrypter.swift
+++ b/Tests/BitcloutIdentityTests/Mocks/MockMessageDecrypter.swift
@@ -12,9 +12,11 @@ class MockMessageDecrypter: MessageDecryptable {
     var mockDecryptedMessages = ["foo": ["bar"], "bar": ["bat"], "bat": ["foo"]]
     var calledDecryptMessages: Bool = false
     var messagesToDecrypt: [EncryptedMessagesThread]?
-    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread]) throws -> [String: [String]] {
+    var publicKeyToDecryptFor: String?
+    func decryptMessages(_ encryptedMessageThreads: [EncryptedMessagesThread], for myPublicKey: String) throws -> [String: [String]] {
         calledDecryptMessages = true
         messagesToDecrypt = encryptedMessageThreads
+        publicKeyToDecryptFor = myPublicKey
         return mockDecryptedMessages
     }
 }


### PR DESCRIPTION
Hooks up the crypto functions to the Message Decrypter. Also added in the ability to decrypt either a single thread, or a collection of them, along with making it optional whether failing to decrypt throws an error or just omits that message from he results.