### PR TITLE
Enabling builds on macOS, primarily so that unit tests can run on CI

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/BitcloutIdentity.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/BitcloutIdentity.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BitcloutIdentity"
+               BuildableName = "BitcloutIdentity"
+               BlueprintName = "BitcloutIdentity"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BitcloutIdentityTests"
+               BuildableName = "BitcloutIdentityTests"
+               BlueprintName = "BitcloutIdentityTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BitcloutIdentityTests"
+               BuildableName = "BitcloutIdentityTests"
+               BlueprintName = "BitcloutIdentityTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BitcloutIdentity"
+            BuildableName = "BitcloutIdentity"
+            BlueprintName = "BitcloutIdentity"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "BitcloutIdentity",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v13),
+        .macOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/BitcloutIdentity/BitcloutIdentity.swift
+++ b/Sources/BitcloutIdentity/BitcloutIdentity.swift
@@ -19,9 +19,17 @@ public class Identity {
     private let context: PresentationContextProvidable
     
     public convenience init() throws {
+        #if os(iOS)
         guard let window = UIApplication.shared.windows.first else {
             throw IdentityError.missingPresentationAnchor
         }
+        let context = PresentationContextProvider(anchor: window)
+        #elseif os(macOS)
+        guard let window = NSApplication.shared.windows.first else {
+            throw IdentityError.missingPresentationAnchor
+        }
+        let context = PresentationContextProvider(anchor: window)
+        #endif
         
         self.init(
             authWorker: AuthWorker(),
@@ -29,7 +37,7 @@ public class Identity {
             transactionSigner: SignTransactionWorker(),
             messageDecrypter: MessageDecryptionWorker(),
             jwtWorker: JWTWorker(),
-            context: PresentationContextProvider(anchor: window)
+            context: context
         )
     }
     

--- a/Tests/BitcloutIdentityTests/Mocks/MockPresentationContextProvider.swift
+++ b/Tests/BitcloutIdentityTests/Mocks/MockPresentationContextProvider.swift
@@ -10,7 +10,11 @@ import AuthenticationServices
 @testable import BitcloutIdentity
 
 class MockPresentationContextProvider: NSObject, PresentationContextProvidable {
+    #if os(iOS)
     var mockPresentationAnchor = UIWindow()
+    #elseif os(macOS)
+    var mockPresentationAnchor = NSWindow()
+    #endif
     var calledPresentationAnchor: Bool = false
     var sessionForAnchor: ASWebAuthenticationSession?
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {


### PR DESCRIPTION
This enables macOS builds, so that we can turn on the GitHub CI to run unit tests